### PR TITLE
Add Minimal Implementation of MEV-Share SSE Collector

### DIFF
--- a/crates/artemis-core/Cargo.toml
+++ b/crates/artemis-core/Cargo.toml
@@ -14,6 +14,7 @@ futures = "0.3"
 tokio-tungstenite = "*"
 async-trait = "0.1.64"
 opensea-stream = { git = "https://github.com/FrankieIsLost/opensea-stream-rs"}
+mev-share-rs = { git = "https://github.com/mattsse/mev-share-rs" }
 ethers-flashbots = { git = "https://github.com/FrankieIsLost/ethers-flashbots", features = ["rustls"] }
 reqwest = { version = "0.11.14", default-features = false, features = ["rustls-tls"] }
 serde = "1.0.152"
@@ -23,7 +24,6 @@ async-stream = "0.3.4"
 anyhow = "1.0.70"
 thiserror = "1.0.40"
 tracing = "0.1.37"
-eventsource-client = "0.11.0"
 
 
 [build-dependencies]

--- a/crates/artemis-core/Cargo.toml
+++ b/crates/artemis-core/Cargo.toml
@@ -23,6 +23,7 @@ async-stream = "0.3.4"
 anyhow = "1.0.70"
 thiserror = "1.0.40"
 tracing = "0.1.37"
+eventsource-client = "0.11.0"
 
 
 [build-dependencies]

--- a/crates/artemis-core/src/collectors/mevshare_collector.rs
+++ b/crates/artemis-core/src/collectors/mevshare_collector.rs
@@ -1,0 +1,60 @@
+use async_trait::async_trait;
+use tokio_stream::StreamExt;
+use std::sync::Arc;
+use ethers::types::{H256, H160, Log};
+use serde::{Deserialize, Serialize};
+
+use eventsource_client::{Client, SSE};
+
+use crate::types::{Collector, CollectorStream};
+use anyhow::Result;
+
+/// A collector that listens for new transactions in the mempool, and generates a stream of
+/// [events](Transaction) which contain the transaction.
+pub struct MevShareCollector {
+    mevshare_stream_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Transactions {
+    pub call_data: H256,
+    pub function_selector: H256,
+    pub to: H160
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MevShareEvent {
+    pub hash: H256,
+    pub logs: Option<Vec<Log>>,
+    pub txs: Option<Vec<Transactions>>,
+}
+
+impl MevShareCollector {
+    pub fn new(mevshare_stream_url: String) -> Self {
+        Self { mevshare_stream_url }
+    }
+}
+
+/// Implementation of the [Collector](Collector) trait for the [MempoolCollector](MempoolCollector).
+/// This implementation uses the [PubsubClient](PubsubClient) to subscribe to new transactions.
+// https://mev-share.flashbots.net
+
+#[async_trait]
+impl Collector<MevShareEvent> for MevShareCollector
+{
+    async fn get_event_stream(&self) -> Result<CollectorStream<MevShareEvent>> {
+        let client = eventsource_client::ClientBuilder::for_url(&self.mevshare_stream_url).unwrap().build();
+        let stream = client.stream();
+        let stream = stream.filter_map(|event| {
+            match event.unwrap() {
+                SSE::Event(evt) => { 
+                    let mev_share_event: MevShareEvent = serde_json::from_str(evt.data.as_str()).unwrap();
+                    Some(mev_share_event)
+                },
+                SSE::Comment(_) => None
+            }
+        });
+        Ok(Box::pin(stream))
+    }
+}

--- a/crates/artemis-core/src/collectors/mod.rs
+++ b/crates/artemis-core/src/collectors/mod.rs
@@ -10,3 +10,5 @@ pub mod mempool_collector;
 
 /// This collector listens to a stream of new Opensea orders.
 pub mod opensea_order_collector;
+
+pub mod mevshare_collector;

--- a/crates/artemis-core/tests/main.rs
+++ b/crates/artemis-core/tests/main.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use artemis_core::{
-    collectors::{block_collector::BlockCollector, mempool_collector::MempoolCollector},
+    collectors::{block_collector::BlockCollector, mempool_collector::MempoolCollector, mevshare_collector::MevShareCollector},
     executors::mempool_executor::{MempoolExecutor, SubmitTxToMempool},
     types::{Collector, Executor},
 };
@@ -86,3 +86,13 @@ async fn test_mempool_executor_sends_tx_simple() {
     let tx = provider.get_transaction_count(account, None).await.unwrap();
     assert_eq!(tx, 1.into());
 }
+
+/// Test that mevshare collector correctly emits blocks.
+#[tokio::test]
+async fn test_mevshare_collector_sends_events() {
+    let mevshare_collector = MevShareCollector::new(String::from("https://mev-share.flashbots.net"));
+    let block_stream = mevshare_collector.get_event_stream().await.unwrap();
+    let block_a = block_stream.into_future().await.0.unwrap();
+    assert_eq!(block_a.hash, block_a.hash);
+}
+


### PR DESCRIPTION
Thought I'd get the ball rolling on this. Currently only added a collector following [https://docs.flashbots.net/flashbots-mev-share/searchers/event-stream](https://docs.flashbots.net/flashbots-mev-share/searchers/event-stream). 

I imagine eventually the MEV-Share implementation will have a complementary executor with shared types, so anyone reading feel free to steal this for yourself if doing that.

Added a test as well but wasn't sure what it should test against, any ideas? Also, because MEV-Share has to send out an event before test completes, the test takes an indeterminate amount of time, sometimes ~5s waiting for a streamed event.

Related #4