### PR TITLE
Update README.md with link to installing Anvil

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ The following strategies have been implemented:
 
 ## Build, Test and Run
 
+First, make sure the following are installed: 
+1. [Anvil](https://github.com/foundry-rs/foundry/tree/master/anvil#installing-from-source)
+
 In order to build, first clone the github repo: 
 
 ```sh


### PR DESCRIPTION
Tried to run tests, noticed that they require anvil to be installed.  Updating readme to reflect this