### PR TITLE
Add Seaport v5 contract as part of Seaport 1.5 release

### DIFF
--- a/crates/clients/opensea-v2/resources/sample_response_1.5.json
+++ b/crates/clients/opensea-v2/resources/sample_response_1.5.json
@@ -1,0 +1,94 @@
+{
+  "protocol": "seaport1.5",
+  "fulfillment_data": {
+    "transaction": {
+      "function": "fulfillBasicOrder_efficient_6GL6yc((address,uint256,uint256,address,address,address,uint256,uint256,uint8,uint256,uint256,bytes32,uint256,bytes32,bytes32,uint256,(uint256,address)[],bytes))",
+      "chain": 1,
+      "to": "0x00000000000000adc04c56bf30ac9d3c0aaf14dc",
+      "value": 20000000000000000,
+      "input_data": {
+        "parameters": {
+          "considerationToken": "0x0000000000000000000000000000000000000000",
+          "considerationIdentifier": "0",
+          "considerationAmount": "17700000000000000",
+          "offerer": "0x5980565737bb2885790c79f126d2c862ad1dc8ab",
+          "zone": "0x0000000000000000000000000000000000000000",
+          "offerToken": "0xa604060890923ff400e8c6f5290461a83aedacec",
+          "offerIdentifier": "40482595849772694285173713041642282097106100196042549765489072528810617864193",
+          "offerAmount": "1",
+          "basicOrderType": 5,
+          "startTime": "1684104869",
+          "endTime": "1684191269",
+          "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "salt": "3523028660070183274",
+          "offererConduitKey": "0x0000007b02230091a7ed01230072f7006a004d60a8d4e71d599b8104250f0000",
+          "fulfillerConduitKey": "0x0000007b02230091a7ed01230072f7006a004d60a8d4e71d599b8104250f0000",
+          "totalOriginalAdditionalRecipients": "2",
+          "additionalRecipients": [
+            {
+              "amount": "500000000000000",
+              "recipient": "0x0000a26b00c1f0df003000390027140000faa719"
+            },
+            {
+              "amount": "1800000000000000",
+              "recipient": "0x5980565737bb2885790c79f126d2c862ad1dc8ab"
+            }
+          ],
+          "signature": "0x3b4a6bc91cddd619da1582720cb87bd99b49caca5d706d157084f048de6b76ae041a2d48be10d737bac974b2d112586a223fcf70ed9eaefee90dae19a57b9abd"
+        }
+      }
+    },
+    "orders": [
+      {
+        "parameters": {
+          "offerer": "0x5980565737bb2885790c79f126d2c862ad1dc8ab",
+          "offer": [
+            {
+              "itemType": 3,
+              "token": "0xA604060890923Ff400e8c6f5290461A83AEDACec",
+              "identifierOrCriteria": "40482595849772694285173713041642282097106100196042549765489072528810617864193",
+              "startAmount": "1",
+              "endAmount": "1"
+            }
+          ],
+          "consideration": [
+            {
+              "itemType": 0,
+              "token": "0x0000000000000000000000000000000000000000",
+              "identifierOrCriteria": "0",
+              "startAmount": "17700000000000000",
+              "endAmount": "17700000000000000",
+              "recipient": "0x5980565737Bb2885790c79f126d2C862Ad1Dc8AB"
+            },
+            {
+              "itemType": 0,
+              "token": "0x0000000000000000000000000000000000000000",
+              "identifierOrCriteria": "0",
+              "startAmount": "500000000000000",
+              "endAmount": "500000000000000",
+              "recipient": "0x0000a26b00c1F0DF003000390027140000fAa719"
+            },
+            {
+              "itemType": 0,
+              "token": "0x0000000000000000000000000000000000000000",
+              "identifierOrCriteria": "0",
+              "startAmount": "1800000000000000",
+              "endAmount": "1800000000000000",
+              "recipient": "0x5980565737Bb2885790c79f126d2C862Ad1Dc8AB"
+            }
+          ],
+          "startTime": "1684104869",
+          "endTime": "1684191269",
+          "orderType": 1,
+          "zone": "0x0000000000000000000000000000000000000000",
+          "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "salt": "0x30e44fe68900f16a",
+          "conduitKey": "0x0000007b02230091a7ed01230072f7006a004d60a8d4e71d599b8104250f0000",
+          "totalOriginalConsiderationItems": 3,
+          "counter": 0
+        },
+        "signature": "0x3b4a6bc91cddd619da1582720cb87bd99b49caca5d706d157084f048de6b76ae041a2d48be10d737bac974b2d112586a223fcf70ed9eaefee90dae19a57b9abd"
+      }
+    ]
+  }
+}

--- a/crates/clients/opensea-v2/src/client.rs
+++ b/crates/clients/opensea-v2/src/client.rs
@@ -66,6 +66,18 @@ mod tests {
         println!("{}", d.display());
         let res = std::fs::read_to_string(d).unwrap();
         let res: FulfillListingResponse = serde_json::from_str(&res).unwrap();
+        assert_eq!(res.protocol, "seaport1.4");
         assert_eq!(res.fulfillment_data.transaction.value, 1780000000000000000);
+    }
+
+    #[test]
+    fn can_deserialize_seaport_v5_response() {
+        let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        d.push("resources/sample_response_1.5.json");
+        println!("{}", d.display());
+        let res = std::fs::read_to_string(d).unwrap();
+        let res: FulfillListingResponse = serde_json::from_str(&res).unwrap();
+        assert_eq!(res.protocol, "seaport1.5");
+        assert_eq!(res.fulfillment_data.transaction.value, 20000000000000000);
     }
 }

--- a/crates/clients/opensea-v2/src/constants.rs
+++ b/crates/clients/opensea-v2/src/constants.rs
@@ -4,5 +4,8 @@ pub const SEAPORT_V1: &str = "0x00000000006c3852cbEf3e08E8dF289169EdE581";
 /// Address for the Seaport V4 contract.
 pub const SEAPORT_V4: &str = "0x00000000000001ad428e4906aE43D8F9852d0dD6";
 
+/// Address for the Seaport V5 contract.
+pub const SEAPORT_V5: &str = "0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC";
+
 /// URL for the fulfill listing endpoint on the OpenSea API.
 pub const FULFILL_LISTING_URL: &str = "https://api.opensea.io/v2/listings/fulfillment_data";

--- a/crates/clients/opensea-v2/src/types.rs
+++ b/crates/clients/opensea-v2/src/types.rs
@@ -4,7 +4,7 @@ use ethers::types::{Bytes, Chain, H160, H256, U256};
 use serde::{de, Deserialize, Serialize, Serializer};
 use thiserror::Error;
 
-use super::constants::{SEAPORT_V1, SEAPORT_V4};
+use super::constants::{SEAPORT_V1, SEAPORT_V4, SEAPORT_V5};
 
 /// Request to fulfill a listing on OpenSea.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -44,6 +44,7 @@ pub struct FulfillListingResponse {
 pub enum ProtocolVersion {
     V1_1,
     V1_4,
+    V1_5,
 }
 
 /// Information needed to fulfill the listing.
@@ -133,6 +134,7 @@ fn protocol_version_to_str<S: Serializer>(
     let protocol_version_str = match protocol_version {
         ProtocolVersion::V1_1 => SEAPORT_V1,
         ProtocolVersion::V1_4 => SEAPORT_V4,
+        ProtocolVersion::V1_5 => SEAPORT_V5,
     };
     serializer.serialize_str(protocol_version_str)
 }

--- a/crates/strategies/opensea-sudo-arb/src/types.rs
+++ b/crates/strategies/opensea-sudo-arb/src/types.rs
@@ -34,7 +34,7 @@ pub fn hash_to_fulfill_listing_request(hash: H256) -> FulfillListingRequest {
         listing: Listing {
             hash,
             chain: Chain::Mainnet,
-            protocol_version: ProtocolVersion::V1_4,
+            protocol_version: ProtocolVersion::V1_5,
         },
         fulfiller: Fulfiller {
             address: H160::zero(),


### PR DESCRIPTION
## Description

Add Seaport v1.5 Contract address as part of the Seaport 1.5 release. Without this fix, there is an error when sending the request with the Opensea API. The error is more specifically: 

```INFO opensea_sudo_arb::strategy: Error getting order from opensea: error decoding response body: missing field protocol at line 1 column 57```

### References

Seaport 1.5 release: https://docs.opensea.io/changelog/seaport-1-5-release
Seaport 1.5 contract address: [0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC](https://etherscan.io/address/0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC#code)