### PR TITLE
Update comment error in BlindArb.t.sol

### DIFF
--- a/crates/strategies/mev-share-uni-arb/contracts/test/BlindArb.t.sol
+++ b/crates/strategies/mev-share-uni-arb/contracts/test/BlindArb.t.sol
@@ -101,7 +101,7 @@ contract BlindArbTest is Test {
         console.log("amount out: %s", amount_out);
 
         arb.executeArb__WETH_token0(address(V2), address(V3), ARB_AMOUNT, 0);
-        console.log("ARB BALANCE BEFORE: %s", WETH.balanceOf(address(arb)));
+        console.log("ARB BALANCE AFTER: %s", WETH.balanceOf(address(arb)));
 
     }
 


### PR DESCRIPTION
The console.log of the smart contract test within the new MEV-share strategy has a "before / after" comment that is mistakenly "before / before"