### PR TITLE
Update readme and fix generate strategy in cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cargo test --all
 In order to run the opensea sudoswap arbitrage strategy, you can run the following command: 
 
 ```sh
-cargo run -- --wss <INFURA_OR_ALCHEMY_KEY> --opensea-api-key <OPENSEA_API_KEY> --private-key <PRIVATE_KEY> --arb-contract-address <ARB_CONTRACT_ADDRESS> --bid-percentage <BID_PERCENTAGE>
+cargo run --bin artemis -- --wss <INFURA_OR_ALCHEMY_KEY> --opensea-api-key <OPENSEA_API_KEY> --private-key <PRIVATE_KEY> --arb-contract-address <ARB_CONTRACT_ADDRESS> --bid-percentage <BID_PERCENTAGE>
 ```
 
 where `ARB_CONTRACT_ADDRESS` is the address to which you deploy the [arb contract](/crates/strategies/opensea-sudo-arb/contracts/src/SudoOpenseaArb.sol).


### PR DESCRIPTION
1. the execution command 
```sh
cargo run -- --wss <INFURA_OR_ALCHEMY_KEY> --opensea-api-key <OPENSEA_API_KEY> --private-key <PRIVATE_KEY> --arb-contract-address <ARB_CONTRACT_ADDRESS> --bid-percentage <BID_PERCENTAGE>
```
 in the existing readme is not executed.

Currently, there are two folders in the bin folder, so I modified the command to test the `opensea sudoswap arbitrage strategy`.

2.  When you run the bin cli `cargo run --bin cli -- --strategy-name <NAME>`, it returns a PANIC error if the folder name already exists.

I wrote logic to create the `strategy dir` by checking if it is an already existing folder.

3. Currently, the folder under strategies is named `Kebab case` and the folder created by the cli is `Snake case`, so it is not possible to run the existing `opensea-sudo-arb`.

First, we need to create a
We changed the case to `snake -> kebab` so that we can run the existing strategy.