### PR TITLE
ci: auto-discover all strategies and matrix forge tests across them

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -6,8 +6,25 @@ on:
   pull_request:
 
 jobs:
+  # Discover all strategies in the project
+  strategy-list:
+    name: Strategy list
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: set-matrix
+        run: echo "::set-output name=matrix::$(ls ./crates/strategies | jq -R -s -c 'split("\n")[:-1]')"
+
+  # Matrix across all discovered strategies
   tests:
     runs-on: ubuntu-latest
+    needs: [strategy-list]
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.strategy-list.outputs.matrix) }}
     env:
       ETH_MAINNET_HTTP: https://eth-mainnet.alchemyapi.io/v2/Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf
     steps:
@@ -21,6 +38,5 @@ jobs:
       - name: Foundry version 
         run: forge --version
 
-      # We need to run tests for every strategy independently
-      - name: Run Opensea Sudo Arb tests
-        run: forge test --root ./crates/strategies/opensea-sudo-arb/contracts
+      - name: Run ${{ matrix.target }} tests
+        run: forge test --root ./crates/strategies/${{ matrix.target }}/contracts

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ monitoring/grafana/data/
 
 # Dotenv file
 .env
+
+.idea/


### PR DESCRIPTION
:v: started studying the repo and saw that `mev-share-uni-arb` was not getting tested in ci

this should prevent that step in the future

tested locally with act:

`act --container-architecture linux/amd64 --workflows .github/workflows/contracts.yml`

<details>
  <summary>Local output</summary>

```
[Solidity/Strategy list] 🚀  Start image=ghcr.io/catthehacker/ubuntu:act-latest
[Solidity/Strategy list]   🐳  docker pull image=ghcr.io/catthehacker/ubuntu:act-latest platform=linux/amd64 username= forcePull=false
[Solidity/Strategy list]   🐳  docker create image=ghcr.io/catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Solidity/Strategy list]   🐳  docker run image=ghcr.io/catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Solidity/Strategy list]   🐳  docker exec cmd=[mkdir -m 0777 -p /var/run/act] user=root workdir=
[Solidity/Strategy list]   🐳  docker cp src=/Users/sam/dev/artemis/. dst=/Users/sam/dev/artemis
[Solidity/Strategy list]   🐳  docker exec cmd=[mkdir -p /Users/sam/dev/artemis] user= workdir=
[Solidity/Strategy list] ⭐  Run actions/checkout@v2
[Solidity/Strategy list]   ✅  Success - actions/checkout@v2
[Solidity/Strategy list] ⭐  Run echo "::set-output name=matrix::$(ls ./crates/strategies | jq -R -s -c 'split("\n")[:-1]')"
[Solidity/Strategy list]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/set-matrix] user= workdir=
[Solidity/Strategy list]   ⚙  ::set-output:: matrix=["mev-share-uni-arb","opensea-sudo-arb"]
[Solidity/Strategy list]   ✅  Success - echo "::set-output name=matrix::$(ls ./crates/strategies | jq -R -s -c 'split("\n")[:-1]')"
[Solidity/tests-2      ] 🧪  Matrix: map[target:opensea-sudo-arb]
[Solidity/tests-2      ] 🚀  Start image=ghcr.io/catthehacker/ubuntu:act-latest
[Solidity/tests-1      ] 🧪  Matrix: map[target:mev-share-uni-arb]
[Solidity/tests-1      ] 🚀  Start image=ghcr.io/catthehacker/ubuntu:act-latest
[Solidity/tests-1      ]   🐳  docker pull image=ghcr.io/catthehacker/ubuntu:act-latest platform=linux/amd64 username= forcePull=false
[Solidity/tests-2      ]   🐳  docker pull image=ghcr.io/catthehacker/ubuntu:act-latest platform=linux/amd64 username= forcePull=false
[Solidity/tests-2      ]   🐳  docker create image=ghcr.io/catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Solidity/tests-1      ]   🐳  docker create image=ghcr.io/catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Solidity/tests-2      ]   🐳  docker run image=ghcr.io/catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Solidity/tests-1      ]   🐳  docker run image=ghcr.io/catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Solidity/tests-2      ]   🐳  docker exec cmd=[mkdir -m 0777 -p /var/run/act] user=root workdir=
[Solidity/tests-1      ]   🐳  docker exec cmd=[mkdir -m 0777 -p /var/run/act] user=root workdir=
[Solidity/tests-2      ]   🐳  docker cp src=/Users/sam/dev/artemis/. dst=/Users/sam/dev/artemis
[Solidity/tests-2      ]   🐳  docker exec cmd=[mkdir -p /Users/sam/dev/artemis] user= workdir=
[Solidity/tests-1      ]   🐳  docker cp src=/Users/sam/dev/artemis/. dst=/Users/sam/dev/artemis
[Solidity/tests-1      ]   🐳  docker exec cmd=[mkdir -p /Users/sam/dev/artemis] user= workdir=
[Solidity/tests-2      ] ⭐  Run actions/checkout@v2
[Solidity/tests-2      ]   ✅  Success - actions/checkout@v2
[Solidity/tests-1      ] ⭐  Run actions/checkout@v2
[Solidity/tests-1      ]   ✅  Success - actions/checkout@v2
[Solidity/tests-2      ] ⭐  Run Install Foundry
[Solidity/tests-2      ]   ☁  git clone 'https://github.com/onbjerg/foundry-toolchain' # ref=v1
[Solidity/tests-1      ] ⭐  Run Install Foundry
[Solidity/tests-1      ]   ☁  git clone 'https://github.com/onbjerg/foundry-toolchain' # ref=v1
[Solidity/tests-2      ]   🐳  docker cp src=/Users/sam/.cache/act/onbjerg-foundry-toolchain@v1/ dst=/var/run/act/actions/onbjerg-foundry-toolchain@v1/
[Solidity/tests-2      ]   🐳  docker exec cmd=[mkdir -p /var/run/act/actions/onbjerg-foundry-toolchain@v1/] user= workdir=
[Solidity/tests-1      ]   🐳  docker cp src=/Users/sam/.cache/act/onbjerg-foundry-toolchain@v1/ dst=/var/run/act/actions/onbjerg-foundry-toolchain@v1/
[Solidity/tests-1      ]   🐳  docker exec cmd=[mkdir -p /var/run/act/actions/onbjerg-foundry-toolchain@v1/] user= workdir=
[Solidity/tests-2      ]   🐳  docker exec cmd=[node /var/run/act/actions/onbjerg-foundry-toolchain@v1/dist/index.js] user= workdir=
[Solidity/tests-1      ]   🐳  docker exec cmd=[node /var/run/act/actions/onbjerg-foundry-toolchain@v1/dist/index.js] user= workdir=
| Downloading Foundry 'nightly' from: https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_amd64.tar.gz
[Solidity/tests-2      ]   💬  ::debug::Downloading https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_amd64.tar.gz
[Solidity/tests-2      ]   💬  ::debug::Destination /tmp/d4fabce3-ee14-419d-99ff-8009e30a83eb
| Downloading Foundry 'nightly' from: https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_amd64.tar.gz
[Solidity/tests-1      ]   💬  ::debug::Downloading https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_amd64.tar.gz
[Solidity/tests-1      ]   💬  ::debug::Destination /tmp/8040b3de-742f-4e6a-9f02-eefe023ed7fe
[Solidity/tests-1      ]   💬  ::debug::download complete
[Solidity/tests-1      ]   💬  ::debug::Extracting /tmp/8040b3de-742f-4e6a-9f02-eefe023ed7fe
[Solidity/tests-1      ]   💬  ::debug::Checking tar --version
[Solidity/tests-1      ]   💬  ::debug::tar (GNU tar) 1.34%0ACopyright (C) 2021 Free Software Foundation, Inc.%0ALicense GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.%0AThis is free software: you are free to change and redistribute it.%0AThere is NO WARRANTY, to the extent permitted by law.%0A%0AWritten by John Gilmore and Jay Fenlason.
| [command]/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /tmp/c1873a17-2b87-4110-a498-6f9de8f1f33a -f /tmp/8040b3de-742f-4e6a-9f02-eefe023ed7fe
[Solidity/tests-2      ]   💬  ::debug::download complete
[Solidity/tests-2      ]   💬  ::debug::Extracting /tmp/d4fabce3-ee14-419d-99ff-8009e30a83eb
[Solidity/tests-2      ]   💬  ::debug::Checking tar --version
[Solidity/tests-2      ]   💬  ::debug::tar (GNU tar) 1.34%0ACopyright (C) 2021 Free Software Foundation, Inc.%0ALicense GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.%0AThis is free software: you are free to change and redistribute it.%0AThere is NO WARRANTY, to the extent permitted by law.%0A%0AWritten by John Gilmore and Jay Fenlason.
| [command]/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /tmp/086c1522-b1dc-4fb9-abe1-0e0634ae9561 -f /tmp/d4fabce3-ee14-419d-99ff-8009e30a83eb
[Solidity/tests-1      ]   💬  ::debug::Resolved Keys:
[Solidity/tests-1      ]   💬  ::debug::["linux-foundry-chain-fork-88fb49346eb32b983fab9c7a035436ffc603a8d7","linux-foundry-chain-fork-"]
[Solidity/tests-1      ]   💬  ::debug::Checking zstd --version
[Solidity/tests-1      ]   💬  ::debug::*** zstd command line interface 64-bits v1.4.8, by Yann Collet ***
[Solidity/tests-1      ]   💬  ::debug::getCacheEntry - Attempt 1 of 2 failed with error: Cache Service Url not found, unable to restore cache.
[Solidity/tests-2      ]   💬  ::debug::Resolved Keys:
[Solidity/tests-2      ]   💬  ::debug::["linux-foundry-chain-fork-88fb49346eb32b983fab9c7a035436ffc603a8d7","linux-foundry-chain-fork-"]
[Solidity/tests-2      ]   💬  ::debug::Checking zstd --version
[Solidity/tests-2      ]   💬  ::debug::*** zstd command line interface 64-bits v1.4.8, by Yann Collet ***
[Solidity/tests-2      ]   💬  ::debug::getCacheEntry - Attempt 1 of 2 failed with error: Cache Service Url not found, unable to restore cache.
[Solidity/tests-1      ]   💬  ::debug::getCacheEntry - Attempt 2 of 2 failed with error: Cache Service Url not found, unable to restore cache.
[Solidity/tests-2      ]   💬  ::debug::getCacheEntry - Attempt 2 of 2 failed with error: Cache Service Url not found, unable to restore cache.
[Solidity/tests-1      ]   🚧  ::warning::Failed to restore: getCacheEntry failed: Cache Service Url not found, unable to restore cache.
[Solidity/tests-1      ]   💬  ::debug::Failed to delete archive: Error: ENOENT: no such file or directory, unlink ''
[Solidity/tests-1      ]   ✅  Success - Install Foundry
[Solidity/tests-1      ] ⭐  Run Foundry version
[Solidity/tests-1      ]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/2] user= workdir=
| forge 0.2.0 (06a17bf 2023-08-19T00:14:54.453240995Z)
[Solidity/tests-1      ]   ✅  Success - Foundry version
[Solidity/tests-1      ] ⭐  Run Run ${{ matrix.target }} tests
[Solidity/tests-1      ]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/3] user= workdir=
[Solidity/tests-2      ]   🚧  ::warning::Failed to restore: getCacheEntry failed: Cache Service Url not found, unable to restore cache.
[Solidity/tests-2      ]   💬  ::debug::Failed to delete archive: Error: ENOENT: no such file or directory, unlink ''
[Solidity/tests-2      ]   ✅  Success - Install Foundry
[Solidity/tests-2      ] ⭐  Run Foundry version
[Solidity/tests-2      ]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/2] user= workdir=
| forge 0.2.0 (06a17bf 2023-08-19T00:14:54.453240995Z)
[Solidity/tests-2      ]   ✅  Success - Foundry version
[⠢] Compiling...
[Solidity/tests-2      ] ⭐  Run Run ${{ matrix.target }} tests
[Solidity/tests-2      ]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/3] user= workdir=
[⠔] Installing solc version 0.8.21
[⠆] Compiling...
[⠃] Successfully installed solc 0.8.21
[⠰] Installing solc version 0.8.21
[⠘] Successfully installed solc 0.8.21
[⠔] Compiling 19 files with 0.8.21
[⠔] Solc 0.8.21 finished in 15.59s
| Compiler run successful with warnings: ...
| 
| Running 1 test for test/BlindArb.t.sol:BlindArbTest
| [PASS] testArb() (gas: 255388)
| Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 4.40s
| Ran 1 test suites: 1 tests passed, 0 failed, 0 skipped (1 total tests)
[Solidity/tests-1      ]   ✅  Success - Run ${{ matrix.target }} tests
[⠒] Compiling 124 files with 0.8.21
[⠊] Solc 0.8.21 finished in 65.91s
| Compiler run successful!
| 
| Running 5 tests for test/SudoOpenseaArb.t.sol:SudoOpenseaArbTest
| [PASS] testFuzzTransferOwnership(address) (runs: 1024, μ: 17324, ~: 17324)
| [PASS] testFuzzTransferOwnershipUnauthorized(address) (runs: 1024, μ: 15295, ~: 15295)
| [PASS] testFuzzWithdraw(uint256) (runs: 1024, μ: 17953, ~: 18150)
| [PASS] testFuzzWithdrawUnauthorized(address) (runs: 1024, μ: 11934, ~: 11934)
| [PASS] testOwner() (gas: 9665)
| Test result: ok. 5 passed; 0 failed; 0 skipped; finished in 656.60ms
| 
| Running 2 tests for test/SudoPairQuoter.t.sol:SudoPairQuoterTest
| [PASS] testCorrectSingleQuote() (gas: 38910)
| [PASS] testCorrectnessMultiQuote() (gas: 50341)
| Test result: ok. 2 passed; 0 failed; 0 skipped; finished in 1.68s
| 
| Running 2 tests for test/SudoOpenseaArbFork.t.sol:SudoOpenseaArbForkTest
| [PASS] testArb() (gas: 475627)
| [PASS] testUnprofitableArb() (gas: 476083)
| Test result: ok. 2 passed; 0 failed; 0 skipped; finished in 5.29s
| Ran 3 test suites: 9 tests passed, 0 failed, 0 skipped (9 total tests)
[Solidity/tests-2      ]   ✅  Success - Run ${{ matrix.target }} tests
```

</details>