### PR TITLE
feat(chainbound): updated `EchoExecutor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,17 +583,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cb-test"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "artemis-core",
- "chainbound-artemis",
- "ethers",
- "tokio",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +611,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-tungstenite 0.20.1",
  "tracing",
 ]
 
@@ -4540,6 +4530,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite 0.20.1",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4781,6 +4785,26 @@ dependencies = [
  "url",
  "utf-8",
  "webpki",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
 ]
 
 [[package]]

--- a/crates/clients/chainbound/Cargo.toml
+++ b/crates/clients/chainbound/Cargo.toml
@@ -9,9 +9,10 @@ readme = "README.md"
 [dependencies]
 artemis-core = { path = "../../artemis-core" }
 ethers = {  version = "2", features = ["ws", "rustls"] }
-fiber = { version = "0.3.3", git = "https://github.com/chainbound/fiber-rs" }
+fiber = { git = "https://github.com/chainbound/fiber-rs" }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 tokio = { version = "1.18", features = ["full"] }
+tokio-tungstenite = { version = "0.20.1", features = ["native-tls"] }
 async-trait = "0.1.64"
 serde = "1.0.152"
 anyhow = "1.0.70"

--- a/crates/clients/chainbound/README.md
+++ b/crates/clients/chainbound/README.md
@@ -62,11 +62,11 @@ pub async fn main() -> anyhow::Result<()> {
     let provider = Arc::new(Provider::connect("wss://eth.llamarpc.com").await.unwrap());
     let tx_signer = LocalWallet::new(&mut rand::thread_rng()); // or any other signer
     let auth_signer = LocalWallet::new(&mut rand::thread_rng()); // or any other signer
-    let echo_executor = Box::new(EchoExecutor::new(provider, tx_signer, auth_signer, api_key));
+    let echo_exec = Box::new(EchoExecutor::new(provider, tx_signer, auth_signer, api_key).await);
 
-    let executor_map = ExecutorMap::new(echo_executor, |action| match action {
-        Action::SendBundle(bundle) => Some(bundle),
-    });
+    // We can simply map all Action types in an Option
+    // since `EchoExecutor` implements `Executor<Action>`.
+    let executor_map = ExecutorMap::new(echo_exec, Some);
 
     // And add these components to your Artemis engine
     let mut engine: Engine<Event, Action> = Engine::default();

--- a/crates/clients/chainbound/src/echo.rs
+++ b/crates/clients/chainbound/src/echo.rs
@@ -159,7 +159,7 @@ where
         // Set block number to the next block if not specified
         if action.standard_features.block_number.is_none() {
             let block_number = self.inner.get_block_number().await?;
-            let next_block_number_hex = format!("0x{:#x}", block_number.as_u64() + 1);
+            let next_block_number_hex = format!("{:#x}", block_number.as_u64() + 1);
             action.standard_features.block_number = Some(next_block_number_hex);
         }
 

--- a/crates/clients/chainbound/src/echo.rs
+++ b/crates/clients/chainbound/src/echo.rs
@@ -1,17 +1,16 @@
-use std::{sync::Arc, time::Duration};
+use std::{borrow::BorrowMut, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use ethers::{providers::Middleware, signers::Signer};
-use reqwest::{
-    header::{HeaderMap, HeaderValue},
-    Client,
-};
+use futures::{SinkExt, StreamExt, TryFutureExt, TryStreamExt};
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::Message;
 use tracing::{debug, error};
 
 use artemis_core::types::Executor;
 
-use crate::SendBundleArgs;
+use crate::{utils, SendBundleArgs, SendPrivateTransactionArgs};
 
 /// Possible actions that can be executed by the Echo executor
 #[derive(Debug, Clone)]
@@ -19,22 +18,25 @@ use crate::SendBundleArgs;
 #[allow(missing_docs)]
 pub enum Action {
     SendBundle(SendBundleArgs),
+    SendPrivateTransaction(SendPrivateTransactionArgs),
 }
 
-const ECHO_RPC_URL: &str = "https://echo-rpc.chainbound.io";
+const ECHO_RPC_URL_WS: &str = "wss://echo-rpc.chainbound.io/ws";
 
 /// An Echo executor that sends transactions to the specified block builders
 pub struct EchoExecutor<M, S> {
     /// The Echo RPC endpoint
     echo_endpoint: String,
-    /// The HTTP client to send requests to the Echo RPC
-    echo_client: Client,
     /// The native ethers middleware
     inner: Arc<M>,
     /// The signer to sign transactions before sending to the builders
     tx_signer: S,
     /// the signer to compute the `X-Flashbots-Signature` of the bundle payload
     auth_signer: S,
+    /// Channel to send websocket messages
+    api_requests_tx: mpsc::Sender<String>,
+    /// Channel to receive websocket messages
+    pub api_responses_rx: mpsc::Receiver<String>,
 }
 
 impl<M: Middleware, S: Signer> EchoExecutor<M, S> {
@@ -45,23 +47,69 @@ impl<M: Middleware, S: Signer> EchoExecutor<M, S> {
     /// - `tx_signer`: The actual signer of the bundle transactions
     /// - `auth_signer`: The signer to compute the `X-Flashbots-Signature` of the bundle payload
     /// - `api_key`: The Echo API key to use
-    pub fn new(inner: Arc<M>, tx_signer: S, auth_signer: S, api_key: impl Into<String>) -> Self {
-        let mut headers = HeaderMap::new();
-        headers.insert("Content-Type", "application/json".parse().unwrap());
-        headers.insert("X-Api-Key", api_key.into().parse().expect("Broken API key"));
+    pub async fn new(
+        inner: Arc<M>,
+        tx_signer: S,
+        auth_signer: S,
+        api_key: impl Into<String>,
+    ) -> Self {
+        let request = tokio_tungstenite::tungstenite::http::Request::builder()
+            .uri(ECHO_RPC_URL_WS)
+            .header("x-api-key", api_key.into())
+            .header("host", "echo-artemis-client")
+            .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+            .header("sec-websocket-version", "13")
+            .header("upgrade", "websocket")
+            .header("connection", "upgrade")
+            .body(())
+            .unwrap();
 
-        let echo_client = Client::builder()
-            .timeout(Duration::from_secs(300))
-            .default_headers(headers)
-            .build()
-            .expect("Could not instantiate HTTP client");
+        let (ws_client, _) = tokio_tungstenite::connect_async(request)
+            .await
+            .expect("Failed to connect to Echo via Websocket.");
+        debug!("Echo websocket handshake succeeded.");
+
+        let (api_requests_tx, mut api_requests_rx) = mpsc::channel(1024);
+        let (api_responses_tx, api_responses_rx) = mpsc::channel(1024);
+
+        // Spawn a task to manage the websocket connection with request and response channels
+        tokio::spawn(async move {
+            let (mut outgoing, incoming) = ws_client.split();
+
+            // send all incoming messages to the responses channel in a separate task
+            tokio::spawn(async move {
+                let responses_tx = api_responses_tx.clone();
+                incoming.try_for_each(|msg| {
+                    let text = msg.into_text().unwrap_or_else(|e| {
+                        error!(error = ?e, "Error converting Echo API response to text");
+                        Default::default()
+                    });
+
+                    responses_tx.send(text).map_err(|e| {
+                        error!(error = ?e, "Error sending Echo API response to the responses channel");
+                        tokio_tungstenite::tungstenite::error::Error::ConnectionClosed
+                    })
+                }).await.ok();
+            });
+
+            // send all messages from the intake channel into the websocket
+            while let Some(msg) = api_requests_rx.recv().await {
+                if let Err(e) = outgoing.send(Message::Text(msg)).await {
+                    error!(error = ?e, "Error sending Echo API request to the websocket")
+                }
+            }
+
+            // websocket has stopped sending messages, alert the user and exit
+            error!("Echo API request channel has stopped sending messages");
+        });
 
         Self {
-            echo_endpoint: ECHO_RPC_URL.into(),
-            echo_client,
+            echo_endpoint: ECHO_RPC_URL_WS.into(),
             inner,
             tx_signer,
             auth_signer,
+            api_requests_tx,
+            api_responses_rx,
         }
     }
 
@@ -72,7 +120,12 @@ impl<M: Middleware, S: Signer> EchoExecutor<M, S> {
 
     /// Returns a reference to the native ethers middleware
     pub fn provider(&self) -> Arc<M> {
-        self.inner.clone()
+        Arc::clone(&self.inner)
+    }
+
+    /// Returns a reference to the API receipts channel
+    pub fn receipts_channel(&mut self) -> &mut mpsc::Receiver<String> {
+        self.api_responses_rx.borrow_mut()
     }
 }
 
@@ -109,45 +162,65 @@ where
         // TODO: Simulate bundle
 
         // Sign bundle payload (without the Echo-specific features)
-        let signable_payload = serde_json::to_string(&action.standard_features)?;
-        let flashbots_signature = self.auth_signer.sign_message(&signable_payload).await?;
+        let method = "eth_sendBundle";
+        let signable_payload = utils::generate_jsonrpc_request(method, &action.standard_features);
+        let fb_signature = utils::generate_fb_signature(&self.auth_signer, &signable_payload).await;
 
-        // Create the `X-Flashbots-Signature` header
-        let flashbots_signature_header: HeaderValue =
-            format!("{:#x}:{}", self.auth_signer.address(), flashbots_signature).parse()?;
-
-        // Prepare the full JSON-RPC request body
-        let bundle_json = serde_json::to_string(&action)?;
-
+        // Websocket usage format:
+        // https://echo.chainbound.io/docs/usage/api-interface#flashbots-authentication
         let request_body = format!(
-            r#"{{"id":1,"jsonrpc":"2.0","method":"eth_sendBundle","params":[{}]}}"#,
-            bundle_json
+            r#"{{"x-flashbots-signature": "{}","payload": {}}}"#,
+            fb_signature,
+            utils::generate_jsonrpc_request(method, action)
         );
 
-        // Send bundle
-        let echo_response = self
-            .echo_client
-            .post(&self.echo_endpoint)
-            .body(request_body)
-            .header("X-Flashbots-Signature", flashbots_signature_header)
-            .send()
-            .await;
+        // Send bundle request
+        self.api_requests_tx.send(request_body).await?;
+        debug!("bundle sent to Echo.");
 
-        match echo_response {
-            Ok(send_response) => {
-                let status = send_response.status();
-                let body = send_response.text().await?;
+        Ok(())
+    }
+}
 
-                dbg!(body.clone());
+#[async_trait]
+impl<M, S> Executor<SendPrivateTransactionArgs> for EchoExecutor<M, S>
+where
+    M: Middleware + 'static,
+    M::Error: 'static,
+    S: Signer + 'static,
+{
+    /// Send a transaction to the specified builders
+    async fn execute(&self, mut action: SendPrivateTransactionArgs) -> Result<()> {
+        let Some(tx) = action.unsigned_tx.take() else {
+            return Err(anyhow!(
+                "SendPrivateTransactionArgs must contain a transaction. 
+                You can set one with the `SendPrivateTransactionArgs::with_tx()` method."
+            ));
+        };
 
-                if status.is_success() {
-                    debug!("Echo bundle response: {:?}", body);
-                } else {
-                    error!("Error in Echo bundle response: {:?}", body);
-                }
-            }
-            Err(send_error) => error!("Error while sending bundle to Echo: {:?}", send_error),
-        }
+        // Sign the transaction
+        let signature = self.tx_signer.sign_transaction(&tx.clone().into()).await?;
+        let signed = tx.rlp_signed(&signature).to_string();
+        action.standard_features.tx = signed;
+
+        // TODO: Simulate transaction
+
+        // Sign payload (without the Echo-specific features)
+        let method = "eth_sendPrivateRawTransaction";
+        let signable_payload = utils::generate_jsonrpc_request(method, &action.standard_features);
+        let fb_signature = utils::generate_fb_signature(&self.auth_signer, &signable_payload).await;
+
+        // Websocket usage format:
+        // https://echo.chainbound.io/docs/usage/api-interface#flashbots-authentication
+        let request_body = format!(
+            r#"{{"x-flashbots-signature": "{}","payload": {}}}"#,
+            fb_signature,
+            utils::generate_jsonrpc_request(method, action)
+        );
+
+        // Send transaction request
+        self.api_requests_tx.send(request_body).await?;
+        debug!("transaction sent to Echo.");
 
         Ok(())
     }

--- a/crates/clients/chainbound/src/fiber.rs
+++ b/crates/clients/chainbound/src/fiber.rs
@@ -1,10 +1,10 @@
-use anyhow::Result;
-use async_trait::async_trait;
-use ethers::types::Transaction;
-use fiber::{
+use ::fiber::{
     eth::{CompactBeaconBlock, ExecutionPayload, ExecutionPayloadHeader},
     Client,
 };
+use anyhow::Result;
+use async_trait::async_trait;
+use ethers::types::Transaction;
 use futures::StreamExt;
 
 use artemis_core::types::{Collector, CollectorStream};

--- a/crates/clients/chainbound/src/lib.rs
+++ b/crates/clients/chainbound/src/lib.rs
@@ -69,7 +69,7 @@ mod tests {
             let auth_signer = LocalWallet::new(&mut rand::thread_rng());
             let account = tx_signer.address();
 
-            let mut echo_exec = EchoExecutor::new(provider, tx_signer, auth_signer, api_key).await;
+            let echo_exec = EchoExecutor::new(provider, tx_signer, auth_signer, api_key).await;
 
             // Fill in the bundle with a random transaction
             let tx = TransactionRequest::new()
@@ -98,7 +98,7 @@ mod tests {
             // ==== Expect a reply by the websocket in the response channel ====
 
             let res = echo_exec.receipts_channel().recv().await.unwrap();
-            let res = serde_json::to_value(res).unwrap();
+            let res = serde_json::from_str::<serde_json::Value>(&res).unwrap();
             assert!(&res["id"] == 2);
             assert!(&res["result"]["bundleHash"] != "0x");
         } else {

--- a/crates/clients/chainbound/src/lib.rs
+++ b/crates/clients/chainbound/src/lib.rs
@@ -83,12 +83,13 @@ mod tests {
 
             // Build the bundle with the selected transaction and options.
             // Look at the `SendBundleArgs` struct for info on available methods.
-            let mut bundle = SendBundleArgs::with_txs(vec![tx]);
-            bundle.set_block_number(next_block.as_u64());
-            bundle.set_mev_builders(vec![BlockBuilder::Flashbots, BlockBuilder::Titan]);
-            bundle.set_replacement_uuid("a34daefc-e640-48fc-a1c7-352fc518720f".to_string());
-            bundle.set_refund_percent(90);
-            bundle.set_refund_index(0);
+            let bundle = SendBundleArgs::with_txs(vec![tx])
+                .set_request_id(2) // id of the request, used to match the response
+                .set_block_number(next_block.as_u64())
+                .set_mev_builders(vec![BlockBuilder::Flashbots, BlockBuilder::Titan])
+                .set_replacement_uuid("a34daefc-e640-48fc-a1c7-352fc518720f".to_string())
+                .set_refund_percent(90)
+                .set_refund_index(0);
 
             if let Err(e) = echo_exec.execute(bundle).await {
                 panic!("Failed to send bundle: {}", e);
@@ -98,6 +99,7 @@ mod tests {
 
             let res = echo_exec.receipts_channel().recv().await.unwrap();
             let res = serde_json::to_value(res).unwrap();
+            assert!(&res["id"] == 2);
             assert!(&res["result"]["bundleHash"] != "0x");
         } else {
             println!("Skipping test_chainbound_clients because FIBER_TEST_KEY is not set");

--- a/crates/clients/chainbound/src/types.rs
+++ b/crates/clients/chainbound/src/types.rs
@@ -43,6 +43,8 @@ pub enum BlockBuilder {
     Nfactorial,
     /// RPC URL: <https://buildai.net/>
     Buildai,
+    /// RPC URL: <https://rpc.smithbuilder.io>
+    Smithbuilder,
 
     /// Custom builder name (must be supported by the Echo RPC).
     /// This can be useful if a new Echo version comes out and this
@@ -66,6 +68,7 @@ impl ToString for BlockBuilder {
             BlockBuilder::Blocknative => "blocknative".to_string(),
             BlockBuilder::Nfactorial => "nfactorial".to_string(),
             BlockBuilder::Buildai => "buildai".to_string(),
+            BlockBuilder::Smithbuilder => "smithbuilder".to_string(),
             BlockBuilder::Other(name) => name.to_string(),
             BlockBuilder::All => "all".to_string(),
         }

--- a/crates/clients/chainbound/src/utils.rs
+++ b/crates/clients/chainbound/src/utils.rs
@@ -8,12 +8,13 @@ use serde::{
 use serde_json::to_string;
 
 /// Generate a JSON-RPC request string.
-pub fn generate_jsonrpc_request<T>(method: &str, params: T) -> String
+pub fn generate_jsonrpc_request<T>(id: u64, method: &str, params: T) -> String
 where
     T: Serialize,
 {
     format!(
-        r#"{{"id":1,"jsonrpc":"2.0","method":"{}","params":[{}]}}"#,
+        r#"{{"id":{},"jsonrpc":"2.0","method":"{}","params":[{}]}}"#,
+        id,
         method,
         to_string(&params).unwrap()
     )

--- a/crates/clients/chainbound/src/utils.rs
+++ b/crates/clients/chainbound/src/utils.rs
@@ -1,0 +1,102 @@
+use std::fmt;
+
+use ethers::{signers::Signer, types::H256, utils::keccak256};
+use serde::{
+    de::{self, Visitor},
+    Deserializer, Serialize,
+};
+use serde_json::to_string;
+
+/// Generate a JSON-RPC request string.
+pub fn generate_jsonrpc_request<T>(method: &str, params: T) -> String
+where
+    T: Serialize,
+{
+    format!(
+        r#"{{"id":1,"jsonrpc":"2.0","method":"{}","params":[{}]}}"#,
+        method,
+        to_string(&params).unwrap()
+    )
+}
+
+/// Generate a Flashbots signature for a given payload
+pub async fn generate_fb_signature<S, T>(signer: &S, payload: T) -> String
+where
+    S: Signer,
+    T: Serialize,
+{
+    let msg = format!(
+        "0x{:x}",
+        H256::from(keccak256(
+            serde_json::to_string(&payload).unwrap().as_bytes()
+        ))
+    );
+
+    let signature = signer.sign_message(msg).await.unwrap();
+
+    format!("{:?}:0x{}", signer.address(), signature)
+}
+
+/// Serialize an optional u64 into a hex string starting with 0x.
+pub fn serialize_opt_u64_as_hex<S>(value: &Option<u64>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    if let Some(value) = value {
+        serializer.serialize_str(&format!("0x{:x}", value))
+    } else {
+        serializer.serialize_none()
+    }
+}
+
+/// Deserialize an optional u64 from a hex string starting with 0x.
+pub fn deserialize_opt_u64_or_hex<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct OptU64OrHex;
+
+    impl<'de> Visitor<'de> for OptU64OrHex {
+        type Value = Option<u64>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("u64 or string starting with 0x")
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserializer.deserialize_any(self)
+        }
+
+        fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(Some(v))
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            if let Some(hex) = v.strip_prefix("0x") {
+                u64::from_str_radix(hex, 16)
+                    .map_err(de::Error::custom)
+                    .map(Some)
+            } else {
+                Err(de::Error::custom("Expected string to start with 0x"))
+            }
+        }
+    }
+
+    deserializer.deserialize_any(OptU64OrHex)
+}


### PR DESCRIPTION
This PR brings new functionality to the chainbound-artemis crate:

New features:

- ability to send private transactions with fully typed `SendPrivateTransactionArgs`
- switched client from HTTP to Websocket, handled with independent request and response channels
- implemented `Executor<Action>` for convenience when using the `EchoExecutor`

Bugs fixed:

- `fiber-rs` version removed from Cargo.toml to avoid future issues with client upgrades
- removed a crate disambiguation with `self::fiber::` in lib.rs